### PR TITLE
Add support for pipenv

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 100

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[FORMAT]
+# Maximum number of characters on a single line.
+max-line-length=100

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+help:
+	@echo  'Commands:'
+	@echo  '  autoformat   - Run black on all the source files, to format them automatically'
+	@echo  '  verify       - Run a bunch of checks, to see if there are any obvious deficiencies in the code'
+	@echo  ''
+
+autoformat:
+	black *.py
+
+verify:
+	flake8 --config=.flake8 *.py
+	pylint --rcfile=.pylintrc *.py
+	bandit *.py

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,20 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+black = "*"
+pylint = "*"
+
+[packages]
+paho-mqtt = "*"
+python-telegram-bot = "*"
+reyaml = "*"
+dataclasses = "*"
+
+[requires]
+python_version = "3.6"
+
+[pipenv]
+allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,8 @@ verify_ssl = true
 [dev-packages]
 black = "*"
 pylint = "*"
+flake8 = "*"
+bandit = "*"
 
 [packages]
 paho-mqtt = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "19a9b380b487149e9643fdaf7fba9f2690f1272298bd96713bcd1d16879d0298"
+            "sha256": "249560d141109944f3bcdac0551a2431997df80d1a69dacab8b4df229b1fdf06"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -165,10 +165,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:8a8d8f610ab3646f89f4c1b89385446e2675c3b7139a577116fa966d33a81d6d",
-                "sha256:91f52b4e4645ee610a82841aacc7ecd0202f695375cc7b34bae43ab4ab359099"
+                "sha256:39183aecc01d6f74eb54edc6739992e842f3bf3068bdfaaba30b5a1742f44091",
+                "sha256:62bd1d8d2ace3e812b3a22eb3c4b7856536d8cc0cdb37466f6a53cf881dbad1f"
             ],
-            "version": "==2.2.3"
+            "version": "==2.2.4"
         },
         "attrs": {
             "hashes": [
@@ -176,6 +176,14 @@
                 "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
             "version": "==19.1.0"
+        },
+        "bandit": {
+            "hashes": [
+                "sha256:6102b5d6afd9d966df5054e0bdfc2e73a24d0fea400ec25f2e54c134412158d7",
+                "sha256:9413facfe9de1e1bd291d525c784e1beb1a55c9916b51dae12979af63a69ba4c"
+            ],
+            "index": "pypi",
+            "version": "==1.5.1"
         },
         "black": {
             "hashes": [
@@ -191,6 +199,35 @@
                 "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
             ],
             "version": "==7.0"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
+            ],
+            "index": "pypi",
+            "version": "==3.7.7"
+        },
+        "gitdb2": {
+            "hashes": [
+                "sha256:83361131a1836661a155172932a13c08bda2db3674e4caa32368aa6eb02f38c2",
+                "sha256:e3a0141c5f2a3f635c7209d56c496ebe1ad35da82fe4d3ec4aaa36278d70648a"
+            ],
+            "version": "==2.0.5"
+        },
+        "gitpython": {
+            "hashes": [
+                "sha256:563221e5a44369c6b79172f455584c9ebbb122a13368cc82cb4b5addff788f82",
+                "sha256:8237dc5bfd6f1366abeee5624111b9d6879393d84745a507de0fda86043b65a8"
+            ],
+            "version": "==2.1.11"
         },
         "isort": {
             "hashes": [
@@ -240,6 +277,27 @@
             ],
             "version": "==0.6.1"
         },
+        "pbr": {
+            "hashes": [
+                "sha256:8257baf496c8522437e8a6cfe0f15e00aedc6c0e0e7c9d55eeeeab31e0853843",
+                "sha256:8c361cc353d988e4f5b998555c88098b9d5964c2e11acf7b0d21925a66bb5824"
+            ],
+            "version": "==5.1.3"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
+        },
         "pylint": {
             "hashes": [
                 "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
@@ -248,12 +306,32 @@
             "index": "pypi",
             "version": "==2.3.1"
         },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0b83c5697aed17a27efbb631a6a3846501375c6e55112a665b210f223fa69629"
+            ],
+            "version": "==5.1b3"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
                 "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
             ],
             "version": "==1.12.0"
+        },
+        "smmap2": {
+            "hashes": [
+                "sha256:0555a7bf4df71d1ef4218e4807bbf9b201f910174e6e08af2e138d4e517b4dde",
+                "sha256:29a9ffa0497e7f2be94ca0ed1ca1aa3cd4cf25a1f6b4f5f87f74b46ed91d609a"
+            ],
+            "version": "==2.0.5"
+        },
+        "stevedore": {
+            "hashes": [
+                "sha256:7be098ff53d87f23d798a7ce7ae5c31f094f3deb92ba18059b1aeb1ca9fec0a0",
+                "sha256:7d1ce610a87d26f53c087da61f06f9b7f7e552efad2a7f6d2322632b5f932ea2"
+            ],
+            "version": "==1.30.1"
         },
         "toml": {
             "hashes": [
@@ -284,7 +362,7 @@
                 "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
                 "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
-            "markers": "python_version >= '3.7' and implementation_name == 'cpython'",
+            "markers": "implementation_name == 'cpython'",
             "version": "==1.3.1"
         },
         "wrapt": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,297 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "19a9b380b487149e9643fdaf7fba9f2690f1272298bd96713bcd1d16879d0298"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:00b97afa72c233495560a0793cdc86c2571721b4271c0667addc83c417f3d90f",
+                "sha256:0ba1b0c90f2124459f6966a10c03794082a2f3985cd699d7d63c4a8dae113e11",
+                "sha256:0bffb69da295a4fc3349f2ec7cbe16b8ba057b0a593a92cbe8396e535244ee9d",
+                "sha256:21469a2b1082088d11ccd79dd84157ba42d940064abbfa59cf5f024c19cf4891",
+                "sha256:2e4812f7fa984bf1ab253a40f1f4391b604f7fc424a3e21f7de542a7f8f7aedf",
+                "sha256:2eac2cdd07b9049dd4e68449b90d3ef1adc7c759463af5beb53a84f1db62e36c",
+                "sha256:2f9089979d7456c74d21303c7851f158833d48fb265876923edcb2d0194104ed",
+                "sha256:3dd13feff00bddb0bd2d650cdb7338f815c1789a91a6f68fdc00e5c5ed40329b",
+                "sha256:4065c32b52f4b142f417af6f33a5024edc1336aa845b9d5a8d86071f6fcaac5a",
+                "sha256:51a4ba1256e9003a3acf508e3b4f4661bebd015b8180cc31849da222426ef585",
+                "sha256:59888faac06403767c0cf8cfb3f4a777b2939b1fbd9f729299b5384f097f05ea",
+                "sha256:59c87886640574d8b14910840327f5cd15954e26ed0bbd4e7cef95fa5aef218f",
+                "sha256:610fc7d6db6c56a244c2701575f6851461753c60f73f2de89c79bbf1cc807f33",
+                "sha256:70aeadeecb281ea901bf4230c6222af0248c41044d6f57401a614ea59d96d145",
+                "sha256:71e1296d5e66c59cd2c0f2d72dc476d42afe02aeddc833d8e05630a0551dad7a",
+                "sha256:8fc7a49b440ea752cfdf1d51a586fd08d395ff7a5d555dc69e84b1939f7ddee3",
+                "sha256:9b5c2afd2d6e3771d516045a6cfa11a8da9a60e3d128746a7fe9ab36dfe7221f",
+                "sha256:9c759051ebcb244d9d55ee791259ddd158188d15adee3c152502d3b69005e6bd",
+                "sha256:b4d1011fec5ec12aa7cc10c05a2f2f12dfa0adfe958e56ae38dc140614035804",
+                "sha256:b4f1d6332339ecc61275bebd1f7b674098a66fea11a00c84d1c58851e618dc0d",
+                "sha256:c030cda3dc8e62b814831faa4eb93dd9a46498af8cd1d5c178c2de856972fd92",
+                "sha256:c2e1f2012e56d61390c0e668c20c4fb0ae667c44d6f6a2eeea5d7148dcd3df9f",
+                "sha256:c37c77d6562074452120fc6c02ad86ec928f5710fbc435a181d69334b4de1d84",
+                "sha256:c8149780c60f8fd02752d0429246088c6c04e234b895c4a42e1ea9b4de8d27fb",
+                "sha256:cbeeef1dc3c4299bd746b774f019de9e4672f7cc666c777cd5b409f0b746dac7",
+                "sha256:e113878a446c6228669144ae8a56e268c91b7f1fafae927adc4879d9849e0ea7",
+                "sha256:e21162bf941b85c0cda08224dade5def9360f53b09f9f259adb85fc7dd0e7b35",
+                "sha256:fb6934ef4744becbda3143d30c6604718871495a5e36c408431bf33d9c146889"
+            ],
+            "version": "==1.12.2"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:066f815f1fe46020877c5983a7e747ae140f517f1b09030ec098503575265ce1",
+                "sha256:210210d9df0afba9e000636e97810117dc55b7157c903a55716bb73e3ae07705",
+                "sha256:26c821cbeb683facb966045e2064303029d572a87ee69ca5a1bf54bf55f93ca6",
+                "sha256:2afb83308dc5c5255149ff7d3fb9964f7c9ee3d59b603ec18ccf5b0a8852e2b1",
+                "sha256:2db34e5c45988f36f7a08a7ab2b69638994a8923853dec2d4af121f689c66dc8",
+                "sha256:409c4653e0f719fa78febcb71ac417076ae5e20160aec7270c91d009837b9151",
+                "sha256:45a4f4cf4f4e6a55c8128f8b76b4c057027b27d4c67e3fe157fa02f27e37830d",
+                "sha256:48eab46ef38faf1031e58dfcc9c3e71756a1108f4c9c966150b605d4a1a7f659",
+                "sha256:6b9e0ae298ab20d371fc26e2129fd683cfc0cfde4d157c6341722de645146537",
+                "sha256:6c4778afe50f413707f604828c1ad1ff81fadf6c110cb669579dea7e2e98a75e",
+                "sha256:8c33fb99025d353c9520141f8bc989c2134a1f76bac6369cea060812f5b5c2bb",
+                "sha256:9873a1760a274b620a135054b756f9f218fa61ca030e42df31b409f0fb738b6c",
+                "sha256:9b069768c627f3f5623b1cbd3248c5e7e92aec62f4c98827059eed7053138cc9",
+                "sha256:9e4ce27a507e4886efbd3c32d120db5089b906979a4debf1d5939ec01b9dd6c5",
+                "sha256:acb424eaca214cb08735f1a744eceb97d014de6530c1ea23beb86d9c6f13c2ad",
+                "sha256:c8181c7d77388fe26ab8418bb088b1a1ef5fde058c6926790c8a0a3d94075a4a",
+                "sha256:d4afbb0840f489b60f5a580a41a1b9c3622e08ecb5eec8614d4fb4cd914c4460",
+                "sha256:d9ed28030797c00f4bc43c86bf819266c76a5ea61d006cd4078a93ebf7da6bfd",
+                "sha256:e603aa7bb52e4e8ed4119a58a03b60323918467ef209e6ff9db3ac382e5cf2c6"
+            ],
+            "version": "==2.6.1"
+        },
+        "dataclasses": {
+            "hashes": [
+                "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f",
+                "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"
+            ],
+            "index": "pypi",
+            "version": "==0.6"
+        },
+        "future": {
+            "hashes": [
+                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
+            ],
+            "version": "==0.17.1"
+        },
+        "paho-mqtt": {
+            "hashes": [
+                "sha256:e440a052b46d222e184be3be38676378722072fcd4dfd2c8f509fb861a7b0b79"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
+        },
+        "python-telegram-bot": {
+            "hashes": [
+                "sha256:29f7397ef7c697bc8a3bef3c26895879258d7a8257daf535259a2dd12b8a0f67",
+                "sha256:a5a520ac3fbfda0f35ecfe3c953a2e220a4ef8a03e6117b46bd24d75580bd277"
+            ],
+            "index": "pypi",
+            "version": "==12.0.0b1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0b83c5697aed17a27efbb631a6a3846501375c6e55112a665b210f223fa69629"
+            ],
+            "version": "==5.1b3"
+        },
+        "reyaml": {
+            "hashes": [
+                "sha256:7af472153db9a08ddc75e0ee0cb6b191f9d48a373109fffd2111c60b278560b8"
+            ],
+            "index": "pypi",
+            "version": "==0.2.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "tornado": {
+            "hashes": [
+                "sha256:1a58f2d603476d5e462f7c28ca1dbb5ac7e51348b27a9cac849cdec3471101f8",
+                "sha256:33f93243cd46dd398e5d2bbdd75539564d1f13f25d704cfc7541db74066d6695",
+                "sha256:34e59401afcecf0381a28228daad8ed3275bcb726810654612d5e9c001f421b7",
+                "sha256:35817031611d2c296c69e5023ea1f9b5720be803e3bb119464bb2a0405d5cd70",
+                "sha256:666b335cef5cc2759c21b7394cff881f71559aaf7cb8c4458af5bb6cb7275b47",
+                "sha256:81203efb26debaaef7158187af45bc440796de9fb1df12a75b65fae11600a255",
+                "sha256:de274c65f45f6656c375cdf1759dbf0bc52902a1e999d12a35eb13020a641a53"
+            ],
+            "version": "==6.0.1"
+        }
+    },
+    "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "astroid": {
+            "hashes": [
+                "sha256:8a8d8f610ab3646f89f4c1b89385446e2675c3b7139a577116fa966d33a81d6d",
+                "sha256:91f52b4e4645ee610a82841aacc7ecd0202f695375cc7b34bae43ab4ab359099"
+            ],
+            "version": "==2.2.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:817243426042db1d36617910df579a54f1afd659adb96fc5032fcf4b36209739",
+                "sha256:e030a9a28f542debc08acceb273f228ac422798e5215ba2a791a6ddeaaca22a5"
+            ],
+            "index": "pypi",
+            "version": "==18.9b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:144c4295314c0ed34fb034f838b2b7e242c52dd3eafdd6f5d49078692f582c0c",
+                "sha256:92a7ddacb0e7e10ed2976e6b5d58496dcda27a3f525c187a3a1a0ae5fa79ff1b"
+            ],
+            "version": "==4.3.10"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+            ],
+            "index": "pypi",
+            "version": "==2.3.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:035a54ede6ce1380599b2ce57844c6554666522e376bd111eb940fbc7c3dad23",
+                "sha256:037c35f2741ce3a9ac0d55abfcd119133cbd821fffa4461397718287092d9d15",
+                "sha256:049feae7e9f180b64efacbdc36b3af64a00393a47be22fa9cb6794e68d4e73d3",
+                "sha256:19228f7940beafc1ba21a6e8e070e0b0bfd1457902a3a81709762b8b9039b88d",
+                "sha256:2ea681e91e3550a30c2265d2916f40a5f5d89b59469a20f3bad7d07adee0f7a6",
+                "sha256:3a6b0a78af298d82323660df5497bcea0f0a4a25a0b003afd0ce5af049bd1f60",
+                "sha256:5385da8f3b801014504df0852bf83524599df890387a3c2b17b7caa3d78b1773",
+                "sha256:606d8afa07eef77280c2bf84335e24390055b478392e1975f96286d99d0cb424",
+                "sha256:69245b5b23bbf7fb242c9f8f08493e9ecd7711f063259aefffaeb90595d62287",
+                "sha256:6f6d839ab09830d59b7fa8fb6917023d8cb5498ee1f1dbd82d37db78eb76bc99",
+                "sha256:730888475f5ac0e37c1de4bd05eeb799fdb742697867f524dc8a4cd74bcecc23",
+                "sha256:9819b5162ffc121b9e334923c685b0d0826154e41dfe70b2ede2ce29034c71d8",
+                "sha256:9e60ef9426efab601dd9aa120e4ff560f4461cf8442e9c0a2b92548d52800699",
+                "sha256:af5fbdde0690c7da68e841d7fc2632345d570768ea7406a9434446d7b33b0ee1",
+                "sha256:b64efdbdf3bbb1377562c179f167f3bf301251411eb5ac77dec6b7d32bcda463",
+                "sha256:bac5f444c118aeb456fac1b0b5d14c6a71ea2a42069b09c176f75e9bd4c186f6",
+                "sha256:bda9068aafb73859491e13b99b682bd299c1b5fd50644d697533775828a28ee0",
+                "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
+                "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
+            ],
+            "markers": "python_version >= '3.7' and implementation_name == 'cpython'",
+            "version": "==1.3.1"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+            ],
+            "version": "==1.11.1"
+        }
+    }
+}

--- a/constants.py
+++ b/constants.py
@@ -1,5 +1,5 @@
-VERSION = '1.2'
-ICON_BUS = '🚌'
+VERSION = "1.2"
+ICON_BUS = "🚌"
 
 QOS_EXACTLY_ONCE = 2  # MQTT quality of service
 
@@ -7,26 +7,35 @@ STATE_EXPECTING_FEEDBACK = 0
 STATE_GOT_FEEDBACK = 1
 
 
-MSG_HELP = 'Încearcă comanda `/prognosis 30`. ' \
-           'Alte comenzi: /feedback, /about.'
-MSG_SAMPLE = 'Iată un exemplu de răspuns la comanda `/prognosis 30`, care arată ' \
-             'timpul de așteptare pentru fiecare stație a rutei 30, care unește ' \
-             'aeroportul cu centrul Chișinăului.'
+MSG_HELP = "Încearcă comanda `/prognosis 30`. " "Alte comenzi: /feedback, /about."
+MSG_SAMPLE = (
+    "Iată un exemplu de răspuns la comanda `/prognosis 30`, care arată "
+    "timpul de așteptare pentru fiecare stație a rutei 30, care unește "
+    "aeroportul cu centrul Chișinăului."
+)
 
-MSG_UNSUPPORTED_ROUTE = 'Cu regret, nu am informații pentru această rută.'
-MSG_ABOUT = f'Roata v{VERSION} lucrează pentru binele public. Spune-le și prietenilor tăi despre mine. ' \
-            'Dacă ai întrebări sau sugestii, folosește comanda /feedback. ' \
-            'Pentru afla despre funcții noi, găsește-ne pe Twitter, @roataway.\n' \
-            'Datele sunt preluate de pe http://rtec.dekart.com/infodash'
-MSG_THANKS = 'Îți mulțumim! Oamenii noștri cei mai buni în curând vor analiza ceea ce ai scris.'
+MSG_UNSUPPORTED_ROUTE = "Cu regret, nu am informații pentru această rută."
+MSG_ABOUT = (
+    f"Roata v{VERSION} lucrează pentru binele public. Spune-le și prietenilor tăi despre mine. "
+    "Dacă ai întrebări sau sugestii, folosește comanda /feedback. "
+    "Pentru afla despre funcții noi, găsește-ne pe Twitter, @roataway.\n"
+    "Datele sunt preluate de pe http://rtec.dekart.com/infodash"
+)
+MSG_THANKS = (
+    "Îți mulțumim! Oamenii noștri cei mai buni în curând vor analiza ceea ce ai scris."
+)
 
-MSG_CHOOSE_ROUTE = 'Alege ruta:'
+MSG_CHOOSE_ROUTE = "Alege ruta:"
 
-MSG_FEEDBACK = 'Scrie aici sugestiile sau întrebările tale, și expediază mesajul. Dacă te-ai răzgândit: /cancel'
-MSG_FEEDBACK_CANCELLED = 'Ehhh.. Ei bine, poate altă dată.'
+MSG_FEEDBACK = "Scrie aici sugestiile sau întrebările tale, și expediază mesajul. Dacă te-ai răzgândit: /cancel"
+MSG_FEEDBACK_CANCELLED = "Ehhh.. Ei bine, poate altă dată."
 
 
-MSG_FEEDBACK_NUDGE = 'Cauți alte rute? Vrei noi funcționalități? Scrie-ne /feedback.'
-MSG_CHANGELOG = 'Află despre schimbări pe <a href="https://twitter.com/roataway">Twitter @roataway</a>, ' \
-                'sau pe Telegram @roataway.'
-MSG_CREDIT = 'Datele sunt preluate de pe <a href="http://rtec.dekart.com/infodash">Infodash</a>.'
+MSG_FEEDBACK_NUDGE = "Cauți alte rute? Vrei noi funcționalități? Scrie-ne /feedback."
+MSG_CHANGELOG = (
+    'Află despre schimbări pe <a href="https://twitter.com/roataway">Twitter @roataway</a>, '
+    "sau pe Telegram @roataway."
+)
+MSG_CREDIT = (
+    'Datele sunt preluate de pe <a href="http://rtec.dekart.com/infodash">Infodash</a>.'
+)

--- a/keyboards.py
+++ b/keyboards.py
@@ -1,5 +1,4 @@
 from telegram import InlineKeyboardButton, KeyboardButton
-import constants as c
 
 # this keyboard is not used at the moment
 # main_board = [[InlineKeyboardButton("Prognoze", callback_data='prognosis')],
@@ -27,4 +26,3 @@ def build_route_menu(routes):
         row.append(InlineKeyboardButton(str(route), callback_data=str(route)))
 
     return [row]
-

--- a/keyboards.py
+++ b/keyboards.py
@@ -10,9 +10,9 @@ import constants as c
 
 
 default_board = [
-                 [KeyboardButton('/prognosis')],
-                 [KeyboardButton('/help'), KeyboardButton('/about'), KeyboardButton('/feedback')]
-                ]
+    [KeyboardButton("/prognosis")],
+    [KeyboardButton("/help"), KeyboardButton("/about"), KeyboardButton("/feedback")],
+]
 
 
 def build_route_menu(routes):

--- a/main.py
+++ b/main.py
@@ -539,4 +539,3 @@ if __name__ == "__main__":
         sys.exit()
     finally:
         log.info("Quitting")
-

--- a/main.py
+++ b/main.py
@@ -5,8 +5,14 @@ import csv
 import os
 
 from reyaml import load_from_file
-from telegram.ext import (Updater, CommandHandler, CallbackQueryHandler, ConversationHandler,
-                          MessageHandler, Filters)
+from telegram.ext import (
+    Updater,
+    CommandHandler,
+    CallbackQueryHandler,
+    ConversationHandler,
+    MessageHandler,
+    Filters,
+)
 from telegram import InlineKeyboardMarkup, ReplyKeyboardMarkup, ParseMode
 
 from structures import Route, Transport
@@ -14,8 +20,7 @@ import constants as c
 import keyboards as k
 from mqtt_client import MqttClient
 
-log = logging.getLogger('infobot')
-
+log = logging.getLogger("infobot")
 
 
 class Infobot:
@@ -23,7 +28,7 @@ class Infobot:
         """Constructor
         :param mqtt: instance of MqttClient object
         :param bot: instance of Telegram bot object
-        :param config: dict, the raw config (normally loaded from YAML)""" 
+        :param config: dict, the raw config (normally loaded from YAML)"""
         self.mqtt = mqtt
         self.bot = bot
         self.config = config
@@ -43,29 +48,28 @@ class Infobot:
         # state of this transport unit
         # TODO should be an expiring dict
         self.transports = {}
-        
-        self.feedback_chat_id = self.config['telegram']['feedback_chat_id']
 
+        self.feedback_chat_id = self.config["telegram"]["feedback_chat_id"]
 
     def refresh_transport(self, data):
         """Update the state info of a given transport
         :param data: dict, the metadata about the transport whereabouts, the keys
                      are:  rtu_id, board, route, lat, lon, speed, dir"""
         try:
-            transport = self.transports[data['board']]
+            transport = self.transports[data["board"]]
         except KeyError:
             transport = Transport()
-            transport.board_name = data['board']
-            transport.rtu_id = data['rtu_id']
-            transport.route = data['route']
-            self.transports[data['board']] = transport
+            transport.board_name = data["board"]
+            transport.rtu_id = data["rtu_id"]
+            transport.route = data["route"]
+            self.transports[data["board"]] = transport
 
-        transport.latitude = data['lat']
-        transport.longitude = data['lon']
-        transport.speed = data['speed']
-        transport.direction = data['dir']
+        transport.latitude = data["lat"]
+        transport.longitude = data["lon"]
+        transport.speed = data["speed"]
+        transport.direction = data["dir"]
         try:
-            transport.last_station_order = data['last_station']
+            transport.last_station_order = data["last_station"]
         except KeyError:
             # the key isn't there, it means the backend doesn't have this info
             # yet. We ignore it for now, the info will be here within a few iterations
@@ -77,7 +81,7 @@ class Infobot:
         :param path: str, full path to CSV file
         :param route_name: str, human-readable name of the route"""
         segments = []
-        last_segment = ''
+        last_segment = ""
         cutoff_station_id = None
         station_sequence = []
 
@@ -106,13 +110,13 @@ class Infobot:
 
     def preload_structures(self):
         """Load information about routes from the available resource files"""
-        log.info('Loading station data')
-        for entry in os.listdir('res/routes'):
+        log.info("Loading station data")
+        for entry in os.listdir("res/routes"):
             route_name, _extension = os.path.splitext(entry)
-            if route_name != '30':
+            if route_name != "30":
                 # for now we only support route 30 and ignore the others
                 continue
-            route = self.load_route(os.path.join('res/routes', entry), route_name)
+            route = self.load_route(os.path.join("res/routes", entry), route_name)
 
             self.routes[route_name] = route
             self.predictions[route_name] = {}
@@ -123,8 +127,12 @@ class Infobot:
 
         # MQTT's loop won't block, it runs in a separate thread
         self.mqtt.set_external_handler(self.on_mqtt)
-        self.mqtt.client.subscribe([('state/station/+', c.QOS_EXACTLY_ONCE),
-                                    ('state/transport/+', c.QOS_EXACTLY_ONCE)])
+        self.mqtt.client.subscribe(
+            [
+                ("state/station/+", c.QOS_EXACTLY_ONCE),
+                ("state/transport/+", c.QOS_EXACTLY_ONCE),
+            ]
+        )
         self.mqtt.client.loop_start()
 
         self.init_bot()
@@ -136,7 +144,7 @@ class Infobot:
         """Retrieve the parameters that were transmitted along with the
         command, if any.
         :param raw: str, the raw text sent by the user"""
-        parts = raw.split(' ', 1)
+        parts = raw.split(" ", 1)
         if len(parts) == 1:
             return None
         else:
@@ -151,28 +159,32 @@ class Infobot:
             return str(data)
 
         # otherwise it is a request for the whole thing
-        result = ''
+        result = ""
         last_prognosis = None
         for station_id in self.routes[route]:
             station_name = self.stations[route][station_id]
             etas = self.predictions[route].get(station_id, [])
             if not etas:
-                result += f'{station_name}: 🚫\n'
+                result += f"{station_name}: 🚫\n"
                 continue
 
-            string_etas = ', '.join([str(item) for item in etas])
+            string_etas = ", ".join([str(item) for item in etas])
             current_prognosis = etas[0]
             if current_prognosis == 0:
                 # it means the trolleybus is there right now, let's add a
                 # trolleybus icon, for a better effect
-                result += f'{c.ICON_BUS} {station_name}: {string_etas}\n'
+                result += f"{c.ICON_BUS} {station_name}: {string_etas}\n"
             else:
-                if last_prognosis is not None and last_prognosis != 0 and current_prognosis < last_prognosis:
+                if (
+                    last_prognosis is not None
+                    and last_prognosis != 0
+                    and current_prognosis < last_prognosis
+                ):
                     # it means we're dealing with the case where the transport is
                     # between stations, so we render a bus icon between stations
                     # result += f'{c.ICON_BUS} în tranzit...\n'
-                    result += f'{c.ICON_BUS}\n'
-                result += f'{station_name}: {string_etas}\n'
+                    result += f"{c.ICON_BUS}\n"
+                result += f"{station_name}: {string_etas}\n"
             last_prognosis = current_prognosis
 
         return result
@@ -186,8 +198,7 @@ class Infobot:
             return str(data)
 
         # otherwise it is a request for the whole thing
-        result = '''*%s*\n''' % self.routes[route].segments[0]
-
+        result = """*%s*\n""" % self.routes[route].segments[0]
 
         last_prognosis = None
         for station_id in self.routes[route].station_sequence:
@@ -195,28 +206,32 @@ class Infobot:
             if station_id == self.routes[route].cutoff_station_id:
                 # for easier readability, we add the header for the return part
                 # of the route
-                result += '\n*%s*\n''' % self.routes[route].segments[0]
+                result += "\n*%s*\n" "" % self.routes[route].segments[0]
 
             station_name = self.all_stations[station_id]
             etas = self.predictions[route].get(station_id, [])
             if not etas:
-                result += f'{station_name}: 🚫\n'
+                result += f"{station_name}: 🚫\n"
                 # result += f'{station_name:<30}: 🚫\n'
                 continue
 
-            string_etas = ', '.join([str(item) for item in etas])
+            string_etas = ", ".join([str(item) for item in etas])
             current_prognosis = etas[0]
             if current_prognosis == 0:
                 # it means the trolleybus is there right now, let's add a
                 # trolleybus icon, for a better effect
-                result += f'{c.ICON_BUS} {station_name}: {string_etas}\n'
+                result += f"{c.ICON_BUS} {station_name}: {string_etas}\n"
             else:
-                if last_prognosis is not None and last_prognosis != 0 and current_prognosis < last_prognosis:
+                if (
+                    last_prognosis is not None
+                    and last_prognosis != 0
+                    and current_prognosis < last_prognosis
+                ):
                     # it means we're dealing with the case where the transport is
                     # between stations, so we render a bus icon between stations
                     # result += f'{c.ICON_BUS} în tranzit...\n'
-                    result += f'{c.ICON_BUS} \n'
-                result += f'{station_name}: {string_etas}\n'
+                    result += f"{c.ICON_BUS} \n"
+                result += f"{station_name}: {string_etas}\n"
             last_prognosis = current_prognosis
 
         return result
@@ -225,13 +240,21 @@ class Infobot:
     def on_bot_start(bot, update):
         """Send a message when the command /start is issued."""
         user = update.effective_user
-        update.message.reply_text(f'Bine ai venit, {user.username or user.full_name}. Roata v{c.VERSION} te ascultă!'
-                                  f'\n Comanda /help îți va arăta ce pot face și va explica '
-                                  f'cum să interpretezi răspunsurile mele.\n\n{c.MSG_HELP}')
-        update.message.reply_text(f'Nu uita să povestești colegilor despre mine. Rrrroata wăy!!!')
+        update.message.reply_text(
+            f"Bine ai venit, {user.username or user.full_name}. Roata v{c.VERSION} te ascultă!"
+            f"\n Comanda /help îți va arăta ce pot face și va explica "
+            f"cum să interpretezi răspunsurile mele.\n\n{c.MSG_HELP}"
+        )
+        update.message.reply_text(
+            f"Nu uita să povestești colegilor despre mine. Rrrroata wăy!!!"
+        )
 
-        bot.sendMessage(chat_id=update.message.chat_id, text='test', parse_mode='HTML',
-                        reply_markup=ReplyKeyboardMarkup(k.default_board, one_time_keyboard=True))
+        bot.sendMessage(
+            chat_id=update.message.chat_id,
+            text="test",
+            parse_mode="HTML",
+            reply_markup=ReplyKeyboardMarkup(k.default_board, one_time_keyboard=True),
+        )
 
     def on_bot_prognosis(self, bot, update):
         """Send a message when the command /prognosis is issued."""
@@ -252,12 +275,19 @@ class Infobot:
 
             etas = self.form_digest_markdown(route)
             # update.message.reply_text(etas)
-            bot.sendMessage(chat_id=update.message.chat_id, text=etas, parse_mode=ParseMode.MARKDOWN)
+            bot.sendMessage(
+                chat_id=update.message.chat_id, text=etas, parse_mode=ParseMode.MARKDOWN
+            )
 
             self.send_locations(bot, update.message.chat_id, route)
-            nudges = c.MSG_FEEDBACK_NUDGE + '\n' + c.MSG_CREDIT + '\n' + c.MSG_CHANGELOG
-            bot.sendMessage(chat_id=update.message.chat_id, text=nudges, parse_mode=ParseMode.HTML,
-                            disable_notification=True, disable_web_page_preview=True)
+            nudges = c.MSG_FEEDBACK_NUDGE + "\n" + c.MSG_CREDIT + "\n" + c.MSG_CHANGELOG
+            bot.sendMessage(
+                chat_id=update.message.chat_id,
+                text=nudges,
+                parse_mode=ParseMode.HTML,
+                disable_notification=True,
+                disable_web_page_preview=True,
+            )
             # update.message.reply_text(nudges)
 
     @staticmethod
@@ -265,7 +295,7 @@ class Infobot:
         """Send a message when the command /help is issued."""
         update.message.reply_text(c.MSG_HELP)
         update.message.reply_text(c.MSG_SAMPLE)
-        update.message.reply_photo(photo=open('res/help-screenshot.png', 'rb'))
+        update.message.reply_photo(photo=open("res/help-screenshot.png", "rb"))
 
     @staticmethod
     def on_bot_about(bot, update):
@@ -284,10 +314,10 @@ class Infobot:
         """Send a message when the command /feeedback is issued."""
         user = update.message.from_user
         raw_text = update.message.text
-        log.info(f'FEED from [{user.username}]: {raw_text}')
+        log.info(f"FEED from [{user.username}]: {raw_text}")
         update.message.reply_text(c.MSG_THANKS)
 
-        report = f'FEED from [{user.username or user.full_name}]: {raw_text}'
+        report = f"FEED from [{user.username or user.full_name}]: {raw_text}"
         bot.sendMessage(chat_id=self.feedback_chat_id, text=report)
         return ConversationHandler.END
 
@@ -317,13 +347,13 @@ class Infobot:
     def feedback_handler(self):
         """This creates a conversation in which we ask the user to provide feedback"""
         handler = ConversationHandler(
-            entry_points=[CommandHandler('feedback', self.on_bot_feedback)],
-
+            entry_points=[CommandHandler("feedback", self.on_bot_feedback)],
             states={
-                c.STATE_EXPECTING_FEEDBACK: [MessageHandler(Filters.text, self.on_bot_feedback_received)]
+                c.STATE_EXPECTING_FEEDBACK: [
+                    MessageHandler(Filters.text, self.on_bot_feedback_received)
+                ]
             },
-
-            fallbacks=[CommandHandler('cancel', self.on_bot_feedback_cancel)]
+            fallbacks=[CommandHandler("cancel", self.on_bot_feedback_cancel)],
         )
         return handler
 
@@ -336,13 +366,23 @@ class Infobot:
 
         etas = self.form_digest_markdown(route)
         # update.message.reply_text(etas)
-        bot.sendMessage(chat_id=query.message.chat_id, text=etas, parse_mode=ParseMode.MARKDOWN, disable_notification=True)
+        bot.sendMessage(
+            chat_id=query.message.chat_id,
+            text=etas,
+            parse_mode=ParseMode.MARKDOWN,
+            disable_notification=True,
+        )
 
         self.send_locations(bot, query.message.chat_id, route)
 
-        nudges = c.MSG_FEEDBACK_NUDGE + '\n' + c.MSG_CREDIT + '\n' + c.MSG_CHANGELOG
-        bot.sendMessage(chat_id=query.message.chat_id, text=nudges, parse_mode=ParseMode.HTML,
-                        disable_notification=True, disable_web_page_preview=True)
+        nudges = c.MSG_FEEDBACK_NUDGE + "\n" + c.MSG_CREDIT + "\n" + c.MSG_CHANGELOG
+        bot.sendMessage(
+            chat_id=query.message.chat_id,
+            text=nudges,
+            parse_mode=ParseMode.HTML,
+            disable_notification=True,
+            disable_web_page_preview=True,
+        )
         # update.message.reply_text(nudges)
 
         # response = self.form_digest(route)
@@ -362,25 +402,37 @@ class Infobot:
         for entry in transports:
             if entry.last_station_order is None:
                 # It must be a non-empty string, hence it is a space.
-                segment_name = ' '
+                segment_name = " "
             else:
-                segment_name = route_obj.segments[0] if entry.last_station_order < route_obj.cutoff_station_id else route_obj.segments[1]
+                segment_name = (
+                    route_obj.segments[0]
+                    if entry.last_station_order < route_obj.cutoff_station_id
+                    else route_obj.segments[1]
+                )
 
-            board_info = f'bord nr. {entry.board_name}'
-            bot.send_venue(chat_id, latitude=entry.latitude, longitude=entry.longitude,
-                           disable_notification=True, title=segment_name, address=board_info)
+            board_info = f"bord nr. {entry.board_name}"
+            bot.send_venue(
+                chat_id,
+                latitude=entry.latitude,
+                longitude=entry.longitude,
+                disable_notification=True,
+                title=segment_name,
+                address=board_info,
+            )
             # bot.send_location(chat_id, latitude=entry.latitude, longitude=entry.longitude, disable_notification=True)
 
         return
 
-
-
-        route_transports = [item for item in self.transports.values() if item.route==route and
-                            # we need the second condition to deal with the cases when it is not
-                            # yet known what station the transport has last visited, so it is
-                            # impossible to determine whether it is before or beyond the
-                            # cut-off point in the route sequence
-                            item.last_station_order is not None]
+        route_transports = [
+            item
+            for item in self.transports.values()
+            if item.route == route and
+            # we need the second condition to deal with the cases when it is not
+            # yet known what station the transport has last visited, so it is
+            # impossible to determine whether it is before or beyond the
+            # cut-off point in the route sequence
+            item.last_station_order is not None
+        ]
 
         if not route_transports:
             # if the list is empty, it means all the transports are offline or missing
@@ -392,39 +444,50 @@ class Infobot:
         route_obj = self.routes[route]
 
         # send info for the first segment
-        bot.sendMessage(chat_id=chat_id, text=route_obj.segments[0], disable_notification=True)
+        bot.sendMessage(
+            chat_id=chat_id, text=route_obj.segments[0], disable_notification=True
+        )
         for entry in route_transports:
             if entry.last_station_order < route_obj.cutoff_station_id:
-                bot.send_location(chat_id, latitude=entry.latitude, longitude=entry.longitude, disable_notification=True)
+                bot.send_location(
+                    chat_id,
+                    latitude=entry.latitude,
+                    longitude=entry.longitude,
+                    disable_notification=True,
+                )
 
         # and then for the second segment
-        bot.sendMessage(chat_id=chat_id, text=route_obj.segments[1], disable_notification=True)
+        bot.sendMessage(
+            chat_id=chat_id, text=route_obj.segments[1], disable_notification=True
+        )
         for entry in route_transports:
             if entry.last_station_order > route_obj.cutoff_station_id:
-                bot.send_location(chat_id, latitude=entry.latitude, longitude=entry.longitude, disable_notification=True)
-
-
+                bot.send_location(
+                    chat_id,
+                    latitude=entry.latitude,
+                    longitude=entry.longitude,
+                    disable_notification=True,
+                )
 
     def on_mqtt(self, client, userdata, msg):
         # log.debug('MQTT IN %s %i bytes `%s`', msg.topic, len(msg.payload), repr(msg.payload))
         try:
             data = json.loads(msg.payload)
         except ValueError:
-            log.debug('Ignoring bad MQTT data %s', repr(msg.payload))
+            log.debug("Ignoring bad MQTT data %s", repr(msg.payload))
             return
 
-        if 'station' in msg.topic:
+        if "station" in msg.topic:
             # we're dealing with data concerning ETA predictions
-            route = list(data['eta'].keys())[0]
-            station_id = data['station_id']
+            route = list(data["eta"].keys())[0]
+            station_id = data["station_id"]
             if route not in self.predictions:
                 # if this route is not yet in our state dict, add it
                 self.predictions[route] = {}
 
             # first, we discard the information about the board numbers, as we won't use it
             # here, we extract just the ETAs
-            predictions = [eta for eta, board in data['eta'][route]]
-
+            predictions = [eta for eta, board in data["eta"][route]]
 
             # sometimes there are dupes, so we turn them into a set, to filter those dupes
             predictions = sorted(list(set(predictions)))
@@ -435,37 +498,45 @@ class Infobot:
             #     predictions = []
             self.predictions[route][station_id] = predictions
 
-        elif 'transport' in msg.topic:
+        elif "transport" in msg.topic:
             # we're dealing with location data about the whereabouts of a trolleybus. The
             # data is a dict with the following keys: rtu_id, board, route, lat, lon, speed, dir
             self.refresh_transport(data)
 
 
-if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG,
-                        # format='%(asctime)s %(levelname)5s %(name)12s  %(threadName)s - %(message)s')
-                        format='%(asctime)s %(levelname)5s %(name)5s - %(message)s')
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.DEBUG,
+        # format='%(asctime)s %(levelname)5s %(name)12s  %(threadName)s - %(message)s')
+        format="%(asctime)s %(levelname)5s %(name)5s - %(message)s",
+    )
 
-    logging.getLogger('telegram').setLevel(logging.WARNING)
-    logging.getLogger('JobQueue').setLevel(logging.WARNING)
-    log.info('Starting Infobot v%s', c.VERSION)
+    logging.getLogger("telegram").setLevel(logging.WARNING)
+    logging.getLogger("JobQueue").setLevel(logging.WARNING)
+    log.info("Starting Infobot v%s", c.VERSION)
 
     config_path = sys.argv[-1]
 
-    log.info('Processing config from `%s`', config_path)
+    log.info("Processing config from `%s`", config_path)
     config = load_from_file(config_path)
 
-    mqtt_conf = config['mqtt']
-    mqtt = MqttClient(name='infobot', broker=mqtt_conf['host'], port=mqtt_conf['port'],
-                      username=mqtt_conf['username'], password=mqtt_conf['password'])
-    bot = Updater(token=config['telegram']['token'])
+    mqtt_conf = config["mqtt"]
+    mqtt = MqttClient(
+        name="infobot",
+        broker=mqtt_conf["host"],
+        port=mqtt_conf["port"],
+        username=mqtt_conf["username"],
+        password=mqtt_conf["password"],
+    )
+    bot = Updater(token=config["telegram"]["token"])
 
     infobot = Infobot(mqtt, bot, config)
 
     try:
         infobot.serve()
     except KeyboardInterrupt:
-        log.debug('Interactive quit')
+        log.debug("Interactive quit")
         sys.exit()
     finally:
-        log.info('Quitting')
+        log.info("Quitting")
+

--- a/mqtt_client.py
+++ b/mqtt_client.py
@@ -1,12 +1,21 @@
 import logging
 import paho.mqtt.client as paho
 
-log = logging.getLogger('mqtt')
+log = logging.getLogger("mqtt")
+
 
 class MqttClient(object):
-    def __init__(self, name, broker='localhost', port=1883,
-                 username=None, password=None, will=None, will_topic=None):
-        '''Create an MQTT client instance, with the optional possibility to set a
+    def __init__(
+        self,
+        name,
+        broker="localhost",
+        port=1883,
+        username=None,
+        password=None,
+        will=None,
+        will_topic=None,
+    ):
+        """Create an MQTT client instance, with the optional possibility to set a
         last will.
 
         :param name:        client identifier
@@ -15,7 +24,7 @@ class MqttClient(object):
         :param username:    str, optional, user
         :param password:    str, optional, password
         :param will:        the last will of the client
-        :param will_topic:  the topic to post the last will to'''
+        :param will_topic:  the topic to post the last will to"""
         self.client = paho.Client(name, False)
         self.client.on_message = self.on_request
         self.external_handler = None
@@ -25,18 +34,16 @@ class MqttClient(object):
 
         if username and password:
             self.client.username_pw_set(username, password)
-        log.debug('Connecting to broker %s:%s', broker, port)
+        log.debug("Connecting to broker %s:%s", broker, port)
         self.client.connect(broker, port=port)
-
 
     def set_external_handler(self, handler):
         self.external_handler = handler
 
-
     def on_request(self, client, userdata, msg):
-        '''Invoked when a message is received on t_requests'''
+        """Invoked when a message is received on t_requests"""
         if self.external_handler:
             self.external_handler(client, userdata, msg)
         else:
-            log.debug('MQTT IN %s %s', msg.topic, msg.payload)
+            log.debug("MQTT IN %s %s", msg.topic, msg.payload)
 

--- a/mqtt_client.py
+++ b/mqtt_client.py
@@ -4,7 +4,7 @@ import paho.mqtt.client as paho
 log = logging.getLogger("mqtt")
 
 
-class MqttClient(object):
+class MqttClient:
     def __init__(
         self,
         name,
@@ -46,4 +46,3 @@ class MqttClient(object):
             self.external_handler(client, userdata, msg)
         else:
             log.debug("MQTT IN %s %s", msg.topic, msg.payload)
-

--- a/readme.rst
+++ b/readme.rst
@@ -22,7 +22,7 @@ Pipenv way
 
 #. Talk to @BotFather to register your bot and get a token, as described here: https://core.telegram.org/bots#6-botfather
 #. Install pipenv ``pip install pipenv``
-#. Then run ``pipenv install``. It will deal automatically with the venv creation and dependecy installing
+#. Then run ``pipenv install --dev``. It will deal automatically with the venv creation and dependecy installing
 #. Make a copy of ``res/config-sample.yaml`` to your own config file, e.g. ``config-development.yaml``, supplying the required information in the file
 #. Run it with ``python main.py res/config-development.yaml``
 
@@ -58,6 +58,11 @@ For historical reasons, the code, comments and the instructions are written in E
 If you made any changes, send a pull request, explaining what you've done and why you've done it.
 
 If you need any help, just ask.
+
+Before commit
+-------------
+1. Run ``make autoformat`` to format all `.py` files
+2. Run ``make verify`` and examine the output, looking for issues that need to be addressed
 
 
 Bot configuration

--- a/readme.rst
+++ b/readme.rst
@@ -16,6 +16,17 @@ How to run it
 #. Make a copy of ``res/config-sample.yaml`` to your own config file, e.g. ``config-development.yaml``, supplying the required information in the file
 #. Run it with ``python main.py res/config-development.yaml``
 
+
+Pipenv way
+==========
+
+#. Talk to @BotFather to register your bot and get a token, as described here: https://core.telegram.org/bots#6-botfather
+#. Install pipenv ``pip install pipenv``
+#. Then run ``pipenv install``. It will deal automatically with the venv creation and dependecy installing
+#. Make a copy of ``res/config-sample.yaml`` to your own config file, e.g. ``config-development.yaml``, supplying the required information in the file
+#. Run it with ``python main.py res/config-development.yaml``
+
+
 The credentials as well as the server connection details are deliberately not a part of this repository. They can be found on rtec.dekart.com/infodash. The ability to figure it out on your own is the qualification barrier for getting started with this bot. Note that ``infodash`` uses WebSTOMP, rather than MQTT; however, the credentials are the same.
 
 

--- a/structures.py
+++ b/structures.py
@@ -7,7 +7,7 @@ log = logging.getLogger("struct")
 @dataclass
 class Route:
     # human-readable name of the route, usually it is a number like "30",
-    # but we still treat them as strings, because they can be something like "30A" 
+    # but we still treat them as strings, because they can be something like "30A"
     name: str
 
     # a list of strings that contains 2 items, corresponding to the directions

--- a/structures.py
+++ b/structures.py
@@ -47,4 +47,3 @@ class Transport:
     # the order number of the last visited station, this is used to display a header above the map
     # with the trolleybus position, to make it obvious which way it is moving.
     last_station_order: int = None
-


### PR DESCRIPTION
 - Include `pipenv` for easy venv management and dependency versions. Also, it's easier to separate prod env dependencies and dev env dependencies.
 - Also, I've included `black` code formater and also format all `.py` files. 
Why `black`? Because there's not much to debate on about the way the formatter is formatting the code, except for the line length which is by default 88 chars.